### PR TITLE
Fix threading

### DIFF
--- a/include/Camera.h
+++ b/include/Camera.h
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <iostream>
+#include <queue>
 #include <random>
 #include <thread>
 #include <vector>
@@ -60,11 +61,14 @@ class Camera
         std::chrono::time_point<std::chrono::system_clock> mEndTime;
 
         bool isRunning;
-        bool isRendering;
+        std::atomic<bool> isRendering;
 
         int mRenderThreads;
         std::vector<std::thread> mRenderThreadPool;
 
         double mIlluminationPercentage;
+        std::atomic<double> mIlluminationPercentageToRender;
+
+        std::queue<double> mIlluminationQueue;
 };
 

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -27,6 +27,7 @@ class Camera
 {
     public:
         Camera(int height, int width, Viewport& canvas);
+        ~Camera();
 
         void SetWidth(int width);
         int GetWidth();

--- a/include/Camera.h
+++ b/include/Camera.h
@@ -7,21 +7,8 @@
 #include <chrono>
 #include <iostream>
 #include <random>
+#include <thread>
 #include <vector>
-
-/*typedef struct
-{
-    double x;
-    double y;
-    double z;
-} point3d;
-
-typedef struct
-{
-    point3d center;
-    point3d color;
-    double radius;
-} sphere3d;*/
 
 class Camera
 {
@@ -35,9 +22,12 @@ class Camera
         void SetHeight(int height);
         int GetHeight();
 
+        void SetIlluminationPercentage(double illuminationPercentage);
+        double GetIlluminationPercentage();
+
         void SetCanvas(Viewport& canvas);
 
-        void DoCameraAction(CameraAction action, double illuminationPercentage);
+        void DoCameraAction(CameraAction action);
 
     private:
         int mHeight;
@@ -52,12 +42,9 @@ class Camera
         std::uniform_int_distribution<unsigned int> mDistribution;
 
 
-
     private:
         void RenderGradient();
-        void RenderWorld(int ThreadNumber, int NumThreads, double illuminationPercentage);
-
-        int mRenderThreads;
+        void RenderWorld(int ThreadNumber, int NumThreads);
 
         point3d mCameraOrigin = { 0, 0, 0 };
         std::vector<std::vector<point3d>> mPixelCoords;
@@ -72,8 +59,12 @@ class Camera
         std::chrono::time_point<std::chrono::system_clock> mStartTime;
         std::chrono::time_point<std::chrono::system_clock> mEndTime;
 
+        bool isRunning;
         bool isRendering;
 
+        int mRenderThreads;
+        std::vector<std::thread> mRenderThreadPool;
 
+        double mIlluminationPercentage;
 };
 

--- a/include/CameraAction.h
+++ b/include/CameraAction.h
@@ -4,5 +4,6 @@ enum class CameraAction
 {
     None = 0,
     DrawWorld = 1,
-    DrawGradient = 2
+    DrawGradient = 2,
+    StopRender = 3
 };

--- a/include/CameraAction.h
+++ b/include/CameraAction.h
@@ -5,5 +5,6 @@ enum class CameraAction
     None = 0,
     DrawWorld = 1,
     DrawGradient = 2,
-    StopRender = 3
+    SliderChanged = 3,
+    StopRender = 4
 };

--- a/lib/Camera.cpp
+++ b/lib/Camera.cpp
@@ -48,6 +48,11 @@ Camera::Camera(int height, int width, Viewport &canvas) : mHeight(480), mWidth(6
     mRenderThreads = 6 * 2;
 }
 
+Camera::~Camera()
+{
+
+}
+
 void Camera::SetWidth(int width)
 {
 	mWidth = width;
@@ -132,31 +137,6 @@ void Camera::RenderWorld(int ThreadNumber, int NumThreads, double illuminationPe
     double magnitude = 0;
     int startingLine = (mHeight / NumThreads) * ThreadNumber - 1;
     int endingLine = (mHeight / NumThreads) * (ThreadNumber - 1);
-
-    constexpr double pi = 3.14159265;
-
-    constexpr double angle = 45;
-    double c = cos(angle * pi / 180);
-    double s = sin(angle * pi / 180);
-
-    mat3d rotmatx = { 1, 0, 0,
-                      0, c, -s,
-                      0, s, c };
-
-    mat3d rotmaty = { c, 0, s,
-                      0, 1, 0,
-                     -s, 0, c };
-
-    mat3d rotmatz = { c, -s, 0,
-                      s, c, 0,
-                      0, 0, 1 };
-
-    mat3d eye = { 1, 0, 0,
-                  0, 1, 0,
-                  0, 0, 1 };
-
-    mCameraOrigin = matMult(eye, mCameraOrigin);
-
 
     for (int i = startingLine; i >= endingLine; i--)
     {

--- a/lib/RaytracerApp.cpp
+++ b/lib/RaytracerApp.cpp
@@ -29,11 +29,11 @@ int RaytracerApp::RunApp()
         GuiApp.UpdateFrame();
         GuiApp.UpdateGui();
 
-        action = GuiApp.GetGuiAction();
         illuminationPercentage = GuiApp.GetIlluminationPercentage();
         camera.SetIlluminationPercentage(illuminationPercentage);
 
         // Should add way to pass data between
+        action = GuiApp.GetGuiAction();
         camera.DoCameraAction(action);
 
         // Reset state, could probably set up a queue, but that's beyond the scope of this project

--- a/lib/RaytracerApp.cpp
+++ b/lib/RaytracerApp.cpp
@@ -31,9 +31,10 @@ int RaytracerApp::RunApp()
 
         action = GuiApp.GetGuiAction();
         illuminationPercentage = GuiApp.GetIlluminationPercentage();
+        camera.SetIlluminationPercentage(illuminationPercentage);
 
         // Should add way to pass data between
-        camera.DoCameraAction(action, illuminationPercentage);
+        camera.DoCameraAction(action);
 
         // Reset state, could probably set up a queue, but that's beyond the scope of this project
         action = CameraAction::None;

--- a/lib/Viewport.cpp
+++ b/lib/Viewport.cpp
@@ -111,10 +111,11 @@ void Viewport::UpdateGui()
 
         ImGui::SliderFloat("Illumination angle", &illuminationSlider, 0.0, 1.0, "%.1f");
 
+
+        mIlluminationPercentage = (double)illuminationSlider;
         if (abs(illuminationSlider - mIlluminationPercentage) > 0.05)
         {
-            mIlluminationPercentage = (double)illuminationSlider;
-            ActionReturned = CameraAction::DrawWorld;
+            ActionReturned = CameraAction::SliderChanged;
         }
 
         if (ImGui::Button("Render"))

--- a/lib/Viewport.cpp
+++ b/lib/Viewport.cpp
@@ -143,6 +143,7 @@ void Viewport::UpdateGui()
 
         if (ImGui::Button("Close"))
         {
+            ActionReturned = CameraAction::StopRender;
             windowShouldClose = true;
         }
         ImGui::End();


### PR DESCRIPTION
Threads are now started on construction of the camera class and are destroyed upon destruction. Furthermore the lighting slider now places illumination percentages into a queue and the queue is emptied in order.